### PR TITLE
feat: use &str rather than String

### DIFF
--- a/keytar-sys/src/lib.cc
+++ b/keytar-sys/src/lib.cc
@@ -2,7 +2,7 @@
 #include "src/lib.rs.h"
 #include <stdexcept>
 
-void set_password(rust::String service, rust::String account, rust::String password)
+void set_password(rust::Str service, rust::Str account, rust::Str password)
 {
   std::string error;
   keytar::KEYTAR_OP_RESULT result = keytar::SetPassword(std::string(service),
@@ -16,7 +16,7 @@ void set_password(rust::String service, rust::String account, rust::String passw
   }
 }
 
-Password get_password(rust::String service, rust::String account)
+Password get_password(rust::Str service, rust::Str account)
 {
   std::string error;
   std::string password;
@@ -39,7 +39,7 @@ Password get_password(rust::String service, rust::String account)
   }
 }
 
-bool delete_password(rust::String service, rust::String account)
+bool delete_password(rust::Str service, rust::Str account)
 {
   std::string error;
   keytar::KEYTAR_OP_RESULT result = keytar::DeletePassword(std::string(service), std::string(account), &error);
@@ -58,7 +58,7 @@ bool delete_password(rust::String service, rust::String account)
   }
 }
 
-Password find_password(rust::String service)
+Password find_password(rust::Str service)
 {
   std::string error;
   std::string password;

--- a/keytar-sys/src/lib.h
+++ b/keytar-sys/src/lib.h
@@ -4,7 +4,7 @@
 
 struct Password;
 
-void set_password(rust::String service, rust::String account, rust::String password);
-Password get_password(rust::String service, rust::String account);
-bool delete_password(rust::String service, rust::String account);
-Password find_password(rust::String service);
+void set_password(rust::Str service, rust::Str account, rust::Str password);
+Password get_password(rust::Str service, rust::Str account);
+bool delete_password(rust::Str service, rust::Str account);
+Password find_password(rust::Str service);

--- a/keytar-sys/src/lib.rs
+++ b/keytar-sys/src/lib.rs
@@ -14,21 +14,21 @@ pub mod ffi {
         /// necessary, or updates an existing entry if one exists.
         ///
         /// Equivalent to [`setPassword`](https://github.com/atom/node-keytar#setpasswordservice-account-password)
-        pub fn set_password(service: String, account: String, password: String) -> Result<()>;
+        pub fn set_password(service: &str, account: &str, password: &str) -> Result<()>;
 
         /// Get the stored password for the service and account.
         ///
         /// Equivalent to [`getPassword`](https://github.com/atom/node-keytar#getpasswordservice-account)
-        pub fn get_password(service: String, account: String) -> Result<Password>;
+        pub fn get_password(service: &str, account: &str) -> Result<Password>;
 
         /// Delete the stored password for the service and account.
         ///
         /// Equivalent to [`deletePassword`](https://github.com/atom/node-keytar#deletepasswordservice-account)
-        pub fn delete_password(service: String, account: String) -> Result<bool>;
+        pub fn delete_password(service: &str, account: &str) -> Result<bool>;
 
         /// Find a password for the service in the keychain.
         ///
         /// Equivalent to [`findPassword`](https://github.com/atom/node-keytar#findpasswordservice)
-        pub fn find_password(service: String) -> Result<Password>;
+        pub fn find_password(service: &str) -> Result<Password>;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,14 @@
 //! the Secret Service API/libsecret, and on Windows they are managed by Credential Vault.
 //!
 //! ```
-//! let service = "service".to_owned();
-//! let account = "account".to_owned();
-//! let password = "password".to_owned();
+//! let service = "service";
+//! let account = "account";
+//! let password = "password";
 //!
 //! # {
-//! # let service = service.clone();
-//! # let account = account.clone();
-//! # let password = password.clone();
+//! # let service = service;
+//! # let account = account;
+//! # let password = password;
 //! keytar::set_password(service, account, password).unwrap();
 //! # }
 //! #

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,31 +1,31 @@
 #[test]
 fn set_password() {
-    let service = "ktr_service".to_owned();
-    let account = "ktr_account".to_owned();
-    let password_in = "ktr_password".to_owned();
-    keytar::set_password(service.clone(), account.clone(), password_in.clone()).unwrap();
+    let service = "ktr_service";
+    let account = "ktr_account";
+    let password_in = "ktr_password";
+    keytar::set_password(service, account, password_in).unwrap();
 
-    let password_out = keytar::get_password(service.clone(), account.clone()).unwrap();
+    let password_out = keytar::get_password(service, account).unwrap();
     assert_eq!(true, password_out.success);
     assert_eq!(password_in, password_out.password);
 
-    keytar::delete_password(service.clone(), account.clone()).unwrap();
+    keytar::delete_password(service, account).unwrap();
 }
 
 #[test]
 fn get_not_existent_password() {
-    let password_out = keytar::get_password("doesn't".to_owned(), "exist".to_owned()).unwrap();
+    let password_out = keytar::get_password("doesn't", "exist").unwrap();
     assert_eq!(false, password_out.success);
 }
 
 #[test]
 fn delete_password() {
-    let service = "ktr_del_service".to_owned();
-    let account = "ktr_del_account".to_owned();
-    let password_in = "ktr_del_password".to_owned();
-    keytar::set_password(service.clone(), account.clone(), password_in.clone()).unwrap();
+    let service = "ktr_del_service";
+    let account = "ktr_del_account";
+    let password_in = "ktr_del_password";
+    keytar::set_password(service, account, password_in).unwrap();
 
-    keytar::delete_password(service.clone(), account.clone()).unwrap();
+    keytar::delete_password(service, account).unwrap();
 
     let password_out = keytar::get_password(service, account).unwrap();
     assert_eq!(false, password_out.success);
@@ -33,14 +33,14 @@ fn delete_password() {
 
 #[test]
 fn find_password() {
-    let service = "ktr_find_service".to_owned();
-    let account = "ktr_find_account".to_owned();
-    let password_in = "ktr_find_password".to_owned();
-    keytar::set_password(service.clone(), account.clone(), password_in.clone()).unwrap();
+    let service = "ktr_find_service";
+    let account = "ktr_find_account";
+    let password_in = "ktr_find_password";
+    keytar::set_password(service, account, password_in).unwrap();
 
-    let password_out = keytar::find_password(service.clone()).unwrap();
+    let password_out = keytar::find_password(service).unwrap();
     assert_eq!(true, password_out.success);
     assert_eq!(password_in, password_out.password);
 
-    keytar::delete_password(service.clone(), account.clone()).unwrap();
+    keytar::delete_password(service, account).unwrap();
 }


### PR DESCRIPTION
I found using this crate a little cumbersome to use having to allocate a string each time I wanted to use the crate's associated functions...

I'm not sure it _needs_ to have strings passed down into it - is there a requirement that these APIs consume a new string each time? It makes more sense to me to use a `&str` here.

Either way, I think this makes for a nicer and easier to use API.
Keen to know your thoughts.