### PR TITLE
Make password return fields public

### DIFF
--- a/keytar-sys/src/lib.rs
+++ b/keytar-sys/src/lib.rs
@@ -3,8 +3,8 @@ pub mod ffi {
     /// Workaround until `cxx` supports `Option`s
     /// https://github.com/dtolnay/cxx/issues/87
     pub struct Password {
-        success: bool,
-        password: String,
+        pub success: bool,
+        pub password: String,
     }
 
     unsafe extern "C++" {


### PR DESCRIPTION
The return Password fields are private. Can't be used then as a library (unless I'm missing something).

This PR changes that.